### PR TITLE
moved cumulative hash away from the constructor

### DIFF
--- a/erc20-migration/contracts/ZTESTBackupVault.sol
+++ b/erc20-migration/contracts/ZTESTBackupVault.sol
@@ -44,8 +44,6 @@ contract ZTESTBackupVault is Ownable {
     /// @notice Smart contract constructor
     /// @param _admin  the only entity authorized to performe restore and distribution operations
     constructor(address _admin) Ownable(_admin) {   
-        _cumulativeHash = bytes32(0);        
-        nextRewardIndex = 0;
     }
 
     /// @notice Set expected cumulative hash after all the data has been loaded

--- a/erc20-migration/contracts/ZTESTBackupVault.sol
+++ b/erc20-migration/contracts/ZTESTBackupVault.sol
@@ -35,14 +35,14 @@ contract ZTESTBackupVault is Ownable {
     error AddressNotValid();
     error CumulativeHashNotValid();
     error CumulativeHashCheckpointReached();
-    error CumulativeHashCehckpointNotSet();
+    error CumulativeHashCheckpointNotSet();
     error UnauthorizedOperation();
     error ERC20NotSet();
     error NothingToDistribute();
 
 
     /// @notice Smart contract constructor
-    /// @param _admin  the only entity authorized to performe restore and distribution operations
+    /// @param _admin  the only entity authorized to perform restore and distribution operations
     constructor(address _admin) Ownable(_admin) {   
     }
 
@@ -60,7 +60,7 @@ contract ZTESTBackupVault is Ownable {
     /// @notice Insert a new batch of tuples (address, value) and updates the cumulative hash.
     ///         To guarantee the same algorithm is applied, the expected cumulativeHash after the batch processing must be provided explicitly)
     function batchInsert(bytes32 expectedCumulativeHash, AddressValue[] memory addressValues) public onlyOwner {
-        if (cumulativeHashCheckpoint == bytes32(0)) revert CumulativeHashCehckpointNotSet();  
+        if (cumulativeHashCheckpoint == bytes32(0)) revert CumulativeHashCheckpointNotSet();  
         uint256 i;
         bytes32 auxHash = _cumulativeHash;
         if(_cumulativeHash == cumulativeHashCheckpoint) revert CumulativeHashCheckpointReached();
@@ -84,10 +84,10 @@ contract ZTESTBackupVault is Ownable {
     /// @notice Distribute ZEN for the next (max) 500 addresses, until we have reached the end of the list
     ///         Can be executed only when we have reached the planned cumulativeHashCheckpoint (meaning all data has been loaded)
     function distribute() public onlyOwner {
-        if (_cumulativeHash != cumulativeHashCheckpoint) revert CumulativeHashNotValid(); //Loaded data not matching - distribution locked
+        if (cumulativeHashCheckpoint == bytes32(0)) revert CumulativeHashCheckpointNotSet();  
         if (address(zenToken) == address(0)) revert ERC20NotSet();
-        if (nextRewardIndex == addressList.length) revert NothingToDistribute();
-        
+        if (_cumulativeHash != cumulativeHashCheckpoint) revert CumulativeHashNotValid(); //Loaded data not matching - distribution locked
+        if (nextRewardIndex == addressList.length) revert NothingToDistribute();        
         uint256 count = 0;
         while (nextRewardIndex < addressList.length && count < 500) {
             address addr = addressList[nextRewardIndex];      

--- a/erc20-migration/contracts/ZTESTZendBackupVault.sol
+++ b/erc20-migration/contracts/ZTESTZendBackupVault.sol
@@ -34,7 +34,7 @@ contract ZTESTZendBackupVault is Ownable {
     error AddressNotValid();
     error CumulativeHashNotValid();
     error CumulativeHashCheckpointReached();
-    error CumulativeHashCehckpointNotSet();
+    error CumulativeHashCheckpointNotSet();
     error UnauthorizedOperation();
     error ERC20NotSet();
     error NothingToClaim(bytes20 zenAddress);
@@ -60,7 +60,7 @@ contract ZTESTZendBackupVault is Ownable {
     ///         The zendAddresses in bs58 decoded format
     ///         To guarantee the same algorithm is applied, the expected cumulativeHash after the batch processing must be provided explicitly)
     function batchInsert(bytes32 expectedCumulativeHash, AddressValue[] memory addressValues) public onlyOwner {
-        if (cumulativeHashCheckpoint == bytes32(0)) revert CumulativeHashCehckpointNotSet();  
+        if (cumulativeHashCheckpoint == bytes32(0)) revert CumulativeHashCheckpointNotSet();  
         uint256 i;
         bytes32 auxHash = _cumulativeHash;
         if(_cumulativeHash == cumulativeHashCheckpoint) revert CumulativeHashCheckpointReached();
@@ -88,7 +88,7 @@ contract ZTESTZendBackupVault is Ownable {
     ///         pubKeyX and pubKeyY are the first 32 bytes and second 32 bytes of the signing key (we use always the uncompressed format here)
     ///         Note: we pass the pubkey explicitly because the extraction from the signature would be GAS expensive.
     function claimP2PKH(address destAddress, bytes memory hexSignature, bytes32 pubKeyX, bytes32 pubKeyY) public {
-        if (cumulativeHashCheckpoint == bytes32(0)) revert CumulativeHashCehckpointNotSet();  
+        if (cumulativeHashCheckpoint == bytes32(0)) revert CumulativeHashCheckpointNotSet();  
         if (_cumulativeHash != cumulativeHashCheckpoint) revert CumulativeHashNotValid(); //Loaded data not matching - distribution locked 
         if (address(zenToken) == address(0)) revert ERC20NotSet();
         if (address(destAddress) == address(0)) revert AddressNotValid();

--- a/erc20-migration/contracts/ZTESTZendBackupVault.sol
+++ b/erc20-migration/contracts/ZTESTZendBackupVault.sol
@@ -43,7 +43,6 @@ contract ZTESTZendBackupVault is Ownable {
     /// @notice Smart contract constructor
     /// @param _admin  the only entity authorized to perform restore operations
     constructor(address _admin) Ownable(_admin) {
-        _cumulativeHash = bytes32(0);
     }
 
     /// @notice Set expected cumulative hash after all the data has been loaded

--- a/erc20-migration/test/mytest.js
+++ b/erc20-migration/test/mytest.js
@@ -38,10 +38,15 @@ describe("Token and EON Backup contract testing", function () {
   it("Deployment of the backup contract", async function () {
     admin = (await ethers.getSigners())[0];
     var factory = await ethers.getContractFactory("ZTESTBackupVault");    
-    ZTESTBackupVault = await factory.deploy(admin, dumpRecursiveHash);
+    ZTESTBackupVault = await factory.deploy(admin);
     console.log(`Contract deployed at: ${ZTESTBackupVault.target}`);
     const receipt = await ZTESTBackupVault.deploymentTransaction().wait(); // Wait for confirmation
     printReceipt("Deploy of backup contract",receipt);
+  });
+
+  it("Set cumulative hash checkpoint in the backup contract", async function () {
+    var res = await ZTESTBackupVault.setCumulativeHashCeckpoint(dumpRecursiveHash);    
+    printReceipt("Set  cumulative hash checkpoin in vault", await res.wait());
   });
 
   it("Store backup balances in the contract (in batches of "+BATCH_LENGTH+")", async function () {

--- a/erc20-migration/test/zenclaim_test.js
+++ b/erc20-migration/test/zenclaim_test.js
@@ -77,7 +77,11 @@ describe("ZEND Claim test", function () {
   it("Deployment of the backup contract", async function () {
     admin = (await ethers.getSigners())[0];
     var factory = await ethers.getContractFactory("ZTESTZendBackupVault");    
-    ZTESTZendBackupVault = await factory.deploy(admin, dumpRecursiveHash);
+    ZTESTZendBackupVault = await factory.deploy(admin);
+  });
+
+  it("Set cumulative hash checkpoint in the backup contract", async function () {
+    await ZTESTZendBackupVault.setCumulativeHashCeckpoint(dumpRecursiveHash);    
   });
 
   it("Store backup balances in the contract", async function () {


### PR DESCRIPTION
Moved cumulative hash checkpoint in a separate method.
This will allow us to pre-deploy ERC-20 and vault contracts before the migration.